### PR TITLE
Fix ECS task definition JSON parsing error

### DIFF
--- a/.github/workflows/gpu-container-AutoDeployTrigger-9a2410cd-d700-45b1-af2d-6a7efeca30f1.yml
+++ b/.github/workflows/gpu-container-AutoDeployTrigger-9a2410cd-d700-45b1-af2d-6a7efeca30f1.yml
@@ -58,7 +58,7 @@ jobs:
         id: register-task-def
         run: |
           # Create a temporary file with proper JSON
-          cat > container-defs.json << 'EOF'
+          cat > container-defs.json << EOF
           [
             {
               "name": "research-assistant-backend",
@@ -105,10 +105,7 @@ jobs:
           ]
           EOF
           
-          # Process the file to replace variables (heredoc with 'EOF' doesn't expand variables)
-          envsubst < container-defs.json > container-defs-processed.json
-          
-          # Register the task definition using the processed file
+          # Register the task definition directly since variables are already expanded in the heredoc
           TASK_DEF=$(aws ecs register-task-definition \
             --family research-assistant-backend \
             --execution-role-arn "${{ secrets.ECS_EXECUTION_ROLE_ARN }}" \
@@ -118,7 +115,7 @@ jobs:
             --cpu 1024 \
             --memory 2048 \
             --runtime-platform cpuArchitecture=X86_64,operatingSystemFamily=LINUX \
-            --container-definitions file://container-defs-processed.json \
+            --container-definitions file://container-defs.json \
             --output json)
           
           # Extract the task definition ARN


### PR DESCRIPTION
## Issue
The deployment workflow is failing with the error "Invalid JSON: Expecting ',' delimiter" when registering the ECS task definition.

## Root Cause
The workflow was using a heredoc with single quotes around the EOF delimiter (`'EOF'`), which prevents variable expansion. This causes the workflow to pass a JSON file with literal `${{ ... }}` strings instead of the expanded values, resulting in invalid JSON.

## Changes
- Removed the single quotes around the EOF delimiter to allow proper variable expansion
- Removed the now unnecessary `envsubst` step since variables will be expanded directly in the heredoc
- Updated the task definition registration to use the container-defs.json file directly

This change should resolve the JSON parsing errors during deployment.